### PR TITLE
fix warning 'networking.k8s.io/v1beta1 Ingress is deprecated in v1.19…

### DIFF
--- a/charts/hello-world/Chart.yaml
+++ b/charts/hello-world/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: Hello world app for Kubernetes with request debug info
 name: hello-world
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.0.0

--- a/charts/hello-world/templates/_helpers.tpl
+++ b/charts/hello-world/templates/_helpers.tpl
@@ -61,3 +61,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "prometheus.kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/hello-world/templates/ingress.yaml
+++ b/charts/hello-world/templates/ingress.yaml
@@ -2,11 +2,7 @@
 {{- $fullName := include "hello-world.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/httpbin/Chart.yaml
+++ b/charts/httpbin/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: httpbin.org for Kubernetes
 name: httpbin
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: latest

--- a/charts/httpbin/templates/_helpers.tpl
+++ b/charts/httpbin/templates/_helpers.tpl
@@ -61,3 +61,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "prometheus.kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/httpbin/templates/ingress.yaml
+++ b/charts/httpbin/templates/ingress.yaml
@@ -2,11 +2,7 @@
 {{- $fullName := include "httpbin.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/redis-commander/Chart.yaml
+++ b/charts/redis-commander/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: redis-commander
 name: redis-commander
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: latest

--- a/charts/redis-commander/templates/_helpers.tpl
+++ b/charts/redis-commander/templates/_helpers.tpl
@@ -61,3 +61,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "prometheus.kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/redis-commander/templates/ingress.yaml
+++ b/charts/redis-commander/templates/ingress.yaml
@@ -2,11 +2,7 @@
 {{- $fullName := include "redis-commander.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/starter/templates/_helpers.tpl
+++ b/starter/templates/_helpers.tpl
@@ -61,3 +61,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19.x" (include "prometheus.kubeVersion" .)) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/starter/templates/ingress.yaml
+++ b/starter/templates/ingress.yaml
@@ -2,11 +2,7 @@
 {{- $fullName := include "<CHARTNAME>.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
…+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress'